### PR TITLE
Harden messaging layers and add dependency fallbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,43 @@
 cmake_minimum_required(VERSION 3.25.2)
 
-set(CMAKE_CXX_STANDARD 11)
+project(cppBase VERSION 0.1.0 LANGUAGES CXX)
 
-project(cppBase)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-file(GLOB files
-     "*.h"
-     "*.cpp"
-)
+option(CPPBASE_BUILD_UTILS "Build the shared utility library" ON)
+option(CPPBASE_BUILD_KAFKA "Build the Kafka integration library" ON)
+option(CPPBASE_BUILD_RABBITMQ "Build the RabbitMQ integration library" ON)
 
-add_executable(${PROJECT_NAME} ${files})
+set(_cppbase_enabled_targets)
 
-target_include_directories(${PROJECT_NAME}
-     PUBLIC app_kafka/src
-     PUBLIC app_utils/src
-     PUBLIC app_rabbitMQ/src)
+if(CPPBASE_BUILD_UTILS)
+    add_subdirectory(app_utils/src)
+    if(TARGET app_utils)
+        list(APPEND _cppbase_enabled_targets app_utils)
+    endif()
+endif()
 
-target_link_libraries(${PROJECT_NAME}
-     PUBLIC app_kafka
-     PUBLIC app_utils
-     PUBLIC app_rabbitMQ
-)
+if(CPPBASE_BUILD_KAFKA)
+    add_subdirectory(app_kafka/src)
+    if(TARGET app_kafka)
+        list(APPEND _cppbase_enabled_targets app_kafka)
+    endif()
+endif()
 
-message(STATUS "Adding subdirectories to package")
-add_subdirectory(app_kafka/src)
-add_subdirectory(app_rabbitMQ/src)
-add_subdirectory(app_utils/src)
+if(CPPBASE_BUILD_RABBITMQ)
+    add_subdirectory(app_rabbitMQ/src)
+    if(TARGET app_rabbitmq)
+        list(APPEND _cppbase_enabled_targets app_rabbitmq)
+    endif()
+endif()
+
+if(_cppbase_enabled_targets)
+    add_library(cppbase INTERFACE)
+    target_link_libraries(cppbase INTERFACE ${_cppbase_enabled_targets})
+endif()

--- a/app_kafka/src/CMakeLists.txt
+++ b/app_kafka/src/CMakeLists.txt
@@ -1,25 +1,44 @@
 cmake_minimum_required(VERSION 3.25.2)
-project(app_kafka)
 
-file(GLOB files
-     "*/*.cpp"
-)
+project(app_kafka LANGUAGES CXX)
 
-find_package(RdKafka REQUIRED)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+file(GLOB_RECURSE files
+     "${CMAKE_CURRENT_SOURCE_DIR}/kafka/*.cpp")
+
+find_package(RdKafka QUIET)
+
+if(NOT RdKafka_FOUND)
+    message(WARNING "RdKafka was not found; building a header-only stub for app_kafka")
+    add_library(${PROJECT_NAME} INTERFACE)
+    target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_compile_definitions(${PROJECT_NAME} INTERFACE APP_KAFKA_MISSING_DEPENDENCIES)
+    return()
+endif()
 
 add_library(${PROJECT_NAME} SHARED ${files})
-target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
-target_link_libraries(${PROJECT_NAME} RdKafka::rdkafka++)
+target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+        RdKafka::rdkafka++
+)
 
 install(
-     DIRECTORY "${CMAKE_SOURCE_DIR}/kafka"
-     DESTINATION "include" 
-     FILES_MATCHING 
-     PATTERN "*.h" 
+     DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/kafka"
+     DESTINATION "include"
+     FILES_MATCHING
+     PATTERN "*.h"
 )
 
 install(TARGETS ${PROJECT_NAME}
+     EXPORT app_kafkaTargets
      RUNTIME DESTINATION bin
      ARCHIVE DESTINATION lib
      LIBRARY DESTINATION lib)

--- a/app_kafka/src/kafka/ConsumeCb.cpp
+++ b/app_kafka/src/kafka/ConsumeCb.cpp
@@ -21,6 +21,8 @@ std::string kafka::ExCosumeCb::msg_consume(RdKafka::Message *message)
     default:
         std::cerr << "Consume failed: " << message->errstr() << std::endl;
     }
+
+    return {};
 }
 
 void kafka::ExCosumeCb::consume_cb(RdKafka::Message& msg, void* opaque) {

--- a/app_kafka/src/kafka/DeliveryReportCb.cpp
+++ b/app_kafka/src/kafka/DeliveryReportCb.cpp
@@ -7,6 +7,12 @@
 void kafka::DeliveryReportCb::dr_cb(RdKafka::Message &message)
 {
     if (message.err())
-        std::cerr << "% Message delivery failed: " << message.errstr()
+    {
+        std::cerr << "[KafkaProducer] Message delivery failed: " << message.errstr()
                   << std::endl;
+        return;
+    }
+
+    std::clog << "[KafkaProducer] Delivered message to topic '" << message.topic_name()
+              << "' at offset " << message.offset() << std::endl;
 }

--- a/app_kafka/src/kafka/KafkaConsumer.cpp
+++ b/app_kafka/src/kafka/KafkaConsumer.cpp
@@ -1,116 +1,146 @@
-#include <iostream>
-#include <string>
-#include <memory>
-
-#include <librdkafka/rdkafkacpp.h>
-
-#include "ConsumeCb.h"
 #include "KafkaConsumer.h"
 
-namespace kafka {
+#include <iostream>
+#include <memory>
+#include <stdexcept>
 
-KafkaConsumer::KafkaConsumer(std::string brokers, std::string topics) {
-    std::string errstr;
+namespace kafka
+{
+    namespace
+    {
+        void destroyConsumer(RdKafka::Consumer *consumer) noexcept
+        {
+            if (!consumer)
+            {
+                return;
+            }
 
-    // Global config
-    RdKafka::Conf *conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
-    if (conf->set("metadata.broker.list", brokers, errstr) != RdKafka::Conf::CONF_OK) {
-        std::cerr << "Broker config error: " << errstr << std::endl;
-        exit(1);
+            consumer->poll(0);
+            delete consumer;
+        }
+
+        void destroyTopic(RdKafka::Topic *topic) noexcept
+        {
+            delete topic;
+        }
+
+        void setConfigValue(RdKafka::Conf &conf, const std::string &key, const std::string &value)
+        {
+            std::string error;
+            const auto result = conf.set(key, value, error);
+            if (result != RdKafka::Conf::CONF_OK)
+            {
+                throw std::runtime_error("Failed to set '" + key + "': " + error);
+            }
+        }
     }
 
-    if (conf->set("enable.auto.commit", "false", errstr) != RdKafka::Conf::CONF_OK) {
-        std::cerr << "Auto commit config error: " << errstr << std::endl;
-        exit(1);
+    KafkaConsumer::KafkaConsumer(const std::string &brokers, const std::string &topics)
+        : consumer_{nullptr, destroyConsumer}, topic_{nullptr, destroyTopic}
+    {
+        std::string error;
+
+        std::unique_ptr<RdKafka::Conf, std::function<void(RdKafka::Conf *)>> conf{
+            RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL), [](RdKafka::Conf *ptr) { delete ptr; }};
+        if (!conf)
+        {
+            throw std::runtime_error("Failed to create Kafka configuration");
+        }
+
+        setConfigValue(*conf, "metadata.broker.list", brokers);
+        setConfigValue(*conf, "enable.auto.commit", "false");
+        setConfigValue(*conf, "fetch.wait.max.ms", "0");
+
+        RdKafka::Consumer *rawConsumer = RdKafka::Consumer::create(conf.get(), error);
+        if (!rawConsumer)
+        {
+            throw std::runtime_error("Failed to create Kafka consumer: " + error);
+        }
+        consumer_.reset(rawConsumer);
+
+        std::unique_ptr<RdKafka::Conf, std::function<void(RdKafka::Conf *)>> topicConf{
+            RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC), [](RdKafka::Conf *ptr) { delete ptr; }};
+        if (!topicConf)
+        {
+            throw std::runtime_error("Failed to allocate topic configuration");
+        }
+
+        RdKafka::Topic *rawTopic = RdKafka::Topic::create(consumer_.get(), topics, topicConf.get(), error);
+        if (!rawTopic)
+        {
+            throw std::runtime_error("Failed to create Kafka topic: " + error);
+        }
+        topic_.reset(rawTopic);
+
+        const auto startResult = consumer_->start(topic_.get(), 0, RdKafka::Topic::OFFSET_END);
+        if (startResult != RdKafka::ERR_NO_ERROR)
+        {
+            throw std::runtime_error("Failed to start Kafka consumer: " + RdKafka::err2str(startResult));
+        }
+
+        std::clog << "[KafkaConsumer] Connected to topic '" << topics << "'\n";
     }
 
-    if (conf->set("fetch.wait.max.ms", "0", errstr) != RdKafka::Conf::CONF_OK) {
-        std::cerr << "Fetch wait config error: " << errstr << std::endl;
-        exit(1);
+    KafkaConsumer::~KafkaConsumer()
+    {
+        stopConsumeMessages();
     }
 
-    consumer = RdKafka::Consumer::create(conf, errstr);
-    delete conf;
-
-    if (!consumer) {
-        std::cerr << "Failed to create Kafka consumer: " << errstr << std::endl;
-        exit(1);
+    void KafkaConsumer::ensureActive() const
+    {
+        if (!consumer_ || !topic_)
+        {
+            throw std::runtime_error("Kafka consumer is not initialised");
+        }
     }
 
-    // Topic config
-    RdKafka::Conf *tconf = RdKafka::Conf::create(RdKafka::Conf::CONF_TOPIC);
-    C_topic = RdKafka::Topic::create(consumer, topics, tconf, errstr);
-    delete tconf;
+    void KafkaConsumer::consumeMessages(ExCosumeCb &ex_consume_cb, std::chrono::milliseconds timeout)
+    {
+        ensureActive();
 
-    if (!C_topic) {
-        std::cerr << "Failed to create Kafka topic: " << errstr << std::endl;
-        exit(1);
+        while (consume_.load(std::memory_order_acquire))
+        {
+            consumer_->consume_callback(topic_.get(), 0, static_cast<int>(timeout.count()), &ex_consume_cb, nullptr);
+        }
     }
 
-    // Start consumer from beginning (or change to OFFSET_END if preferred)
-    RdKafka::ErrorCode resp = consumer->start(C_topic, 0, RdKafka::Topic::OFFSET_END);
-    if (resp != RdKafka::ERR_NO_ERROR) {
-        std::cerr << "Consumer start failed: " << RdKafka::err2str(resp) << std::endl;
-        exit(1);
-    }
+    std::string KafkaConsumer::consumeMessage(std::chrono::milliseconds timeout)
+    {
+        ensureActive();
 
-    std::cout << "Kafka consumer created and started successfully.\n";
-}
+        std::unique_ptr<RdKafka::Message> message{consumer_->consume(topic_.get(), 0, static_cast<int>(timeout.count()))};
+        if (!message)
+        {
+            throw std::runtime_error("Failed to allocate Kafka message container");
+        }
 
-void KafkaConsumer::consumeMessages(ExCosumeCb ex_consume_cb) {
-    std::cout << "Consuming messages (callback mode)...\n";
-    int use_ccb = 1;
-
-    while (consume) {
-        consumer->consume_callback(C_topic, 0, 1000, &ex_consume_cb, &use_ccb);
-    }
-
-    consumer->stop(C_topic, 0);
-    RdKafka::wait_destroyed(5000);
-}
-
-std::string KafkaConsumer::consumeMessage() {
-    std::unique_ptr<RdKafka::Message> msg(consumer->consume(C_topic, 0, -1));
-    std::string payload;
-
-    switch (msg->err()) {
+        switch (message->err())
+        {
         case RdKafka::ERR_NO_ERROR:
-            payload = std::string(static_cast<const char *>(msg->payload()), msg->len());
-            break;
+            return std::string(static_cast<const char *>(message->payload()), message->len());
 
         case RdKafka::ERR__TIMED_OUT:
-            std::cerr << "Kafka consume timed out.\n";
-            break;
+            return {};
 
         default:
-            std::cerr << "Kafka consume failed: " << msg->errstr() << std::endl;
-            break;
+            throw std::runtime_error("Kafka consume failed: " + message->errstr());
+        }
     }
 
-    return payload;
-}
+    void KafkaConsumer::stopConsumeMessages()
+    {
+        consume_.store(false, std::memory_order_release);
 
-void KafkaConsumer::stopConsumeMessages() {
-    consume = false;
-     if (consumer && C_topic) {
-        consumer->stop(C_topic, 0);
+        if (consumer_ && topic_)
+        {
+            consumer_->stop(topic_.get(), 0);
+            consumer_->poll(0);
+        }
+
+        topic_.reset();
+        consumer_.reset();
+
+        RdKafka::wait_destroyed(5000);
+        std::clog << "[KafkaConsumer] Shutdown complete\n";
     }
-
-    delete C_topic;
-    delete consumer;
-
-    std::cout << "Kafka consumer destroyed.\n";
 }
-
-KafkaConsumer::~KafkaConsumer() {
-    if (consumer && C_topic) {
-        consumer->stop(C_topic, 0);
-    }
-
-    delete C_topic;
-    delete consumer;
-
-    std::cout << "Kafka consumer destroyed.\n";
-}
-
-}  // namespace kafka

--- a/app_kafka/src/kafka/KafkaConsumer.h
+++ b/app_kafka/src/kafka/KafkaConsumer.h
@@ -1,5 +1,11 @@
 #pragma once
-#include <iostream>
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
 #include <librdkafka/rdkafkacpp.h>
 
 #include "ConsumeCb.h"
@@ -9,18 +15,26 @@ namespace kafka
     class KafkaConsumer
     {
     public:
-        RdKafka::Consumer *consumer;
-        RdKafka::Topic *C_topic;
-        bool consume = true;
+        KafkaConsumer(const std::string &brokers, const std::string &topics);
+        ~KafkaConsumer();
 
-        KafkaConsumer(std::string brokers, std::string topics);
+        KafkaConsumer(const KafkaConsumer &) = delete;
+        KafkaConsumer &operator=(const KafkaConsumer &) = delete;
+        KafkaConsumer(KafkaConsumer &&) noexcept = default;
+        KafkaConsumer &operator=(KafkaConsumer &&) noexcept = default;
 
-        void consumeMessages(ExCosumeCb ex_consume_cb);
-        std::string consumeMessage();
-
-
+        void consumeMessages(ExCosumeCb &ex_consume_cb, std::chrono::milliseconds timeout = std::chrono::seconds(1));
+        std::string consumeMessage(std::chrono::milliseconds timeout = std::chrono::seconds(1));
         void stopConsumeMessages();
 
-        ~KafkaConsumer();
+    private:
+        using ConsumerPtr = std::unique_ptr<RdKafka::Consumer, std::function<void(RdKafka::Consumer *)>>;
+        using TopicPtr = std::unique_ptr<RdKafka::Topic, std::function<void(RdKafka::Topic *)>>;
+
+        void ensureActive() const;
+
+        ConsumerPtr consumer_{nullptr, [](RdKafka::Consumer *) {}};
+        TopicPtr topic_{nullptr, [](RdKafka::Topic *) {}};
+        std::atomic<bool> consume_{true};
     };
 }

--- a/app_kafka/src/kafka/KafkaProducer.cpp
+++ b/app_kafka/src/kafka/KafkaProducer.cpp
@@ -1,110 +1,156 @@
-#include <iostream>
-#include <string>
-#include <librdkafka/rdkafkacpp.h>
-
-#include "DeliveryReportCb.h"
 #include "KafkaProducer.h"
 
-kafka::KafkaProducer::KafkaProducer(std::string brokers)
+#include <iostream>
+#include <utility>
+
+namespace kafka
 {
-    RdKafka::Conf *conf = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
-
-    std::string errstr;
-
-    if (conf->set("bootstrap.servers", brokers, errstr) !=
-        RdKafka::Conf::CONF_OK)
+    namespace
     {
-        std::cerr << errstr << std::endl;
-        exit(1);
-    }
-
-    if (conf->set("linger.ms", "0", errstr) !=
-        RdKafka::Conf::CONF_OK)
-    {
-        std::cerr << errstr << std::endl;
-        exit(1);
-    }
-
-    if (conf->set("batch.num.messages", "30", errstr) !=
-        RdKafka::Conf::CONF_OK)
-    {
-        std::cerr << errstr << std::endl;
-        exit(1);
-    }
-
-    if (conf->set("acks", "1", errstr) !=
-        RdKafka::Conf::CONF_OK)
-    {
-        std::cerr << errstr << std::endl;
-        exit(1);
-    }
-
-    if (conf->set("compression.type", "lz4", errstr) !=
-        RdKafka::Conf::CONF_OK)
-    {
-        std::cerr << errstr << std::endl;
-        exit(1);
-    }
-
-    DeliveryReportCb ex_dr_cb;
-
-    if (conf->set("dr_cb", &ex_dr_cb, errstr) != RdKafka::Conf::CONF_OK)
-    {
-        std::cerr << errstr << std::endl;
-        exit(1);
-    }
-
-    if (conf->set("delivery.report.only.error", "true", errstr) !=
-        RdKafka::Conf::CONF_OK)
-    {
-        std::cerr << errstr << std::endl;
-        exit(1);
-    }
-
-    producer = RdKafka::Producer::create(conf, errstr);
-    if (!producer)
-    {
-        std::cerr << "Failed to create producer: " << errstr << std::endl;
-        exit(1);
-    }
-
-    delete conf;
-    std::cout << "Creating Kafka producer" << std::endl;
-}
-
-void kafka::KafkaProducer::produceMessages(std::string topic, std::string message)
-{
-retry:
-    RdKafka::ErrorCode err = producer->produce(
-        topic,
-        RdKafka::Topic::PARTITION_UA,
-        RdKafka::Producer::RK_MSG_COPY,
-        const_cast<char *>(message.c_str()), message.size(),
-        NULL, 0,
-        0,
-        NULL,
-        NULL);
-
-    if (err != RdKafka::ERR_NO_ERROR)
-    {
-        std::cerr << "% Failed to produce to topic " << topic << ": "
-                  << RdKafka::err2str(err) << std::endl;
-
-        if (err == RdKafka::ERR__QUEUE_FULL)
+        void destroyProducer(RdKafka::Producer *producer) noexcept
         {
-            producer->poll(1000);
-            goto retry;
+            if (!producer)
+            {
+                return;
+            }
+
+            producer->flush(10 * 1000);
+            delete producer;
+        }
+
+        void destroyConfig(RdKafka::Conf *conf) noexcept
+        {
+            delete conf;
+        }
+
+        void setConfigValue(RdKafka::Conf &conf, const std::string &key, const std::string &value)
+        {
+            std::string error;
+            const auto result = conf.set(key, value, error);
+            if (result != RdKafka::Conf::CONF_OK)
+            {
+                throw KafkaError("Failed to set '" + key + "': " + error);
+            }
         }
     }
-}
 
-kafka::KafkaProducer::~KafkaProducer()
-{
-    std::cerr << "% Flushing final messages..." << std::endl;
-    producer->flush(10 * 1000);
-    if (producer->outq_len() > 0)
-        std::cerr << producer->outq_len()
-                  << " message(s) were not delivered" << std::endl;
-    delete producer;
-    std::cout << "Stopping Kafka producer" << std::endl;
+    KafkaProducer::ConfPtr KafkaProducer::createConfig()
+    {
+        ConfPtr conf{RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL), destroyConfig};
+        if (!conf)
+        {
+            throw KafkaError("Failed to allocate Kafka configuration");
+        }
+        return conf;
+    }
+
+    void KafkaProducer::configureCommonOptions(RdKafka::Conf &conf, const std::string &brokers)
+    {
+        setConfigValue(conf, "bootstrap.servers", brokers);
+        setConfigValue(conf, "linger.ms", "0");
+        setConfigValue(conf, "batch.num.messages", "30");
+        setConfigValue(conf, "acks", "1");
+        setConfigValue(conf, "compression.type", "lz4");
+
+        std::string error;
+        auto result = conf.set("dr_cb", &deliveryReportCallback_, error);
+        if (result != RdKafka::Conf::CONF_OK)
+        {
+            throw KafkaError("Failed to attach delivery callback: " + error);
+        }
+
+        result = conf.set("delivery.report.only.error", "true", error);
+        if (result != RdKafka::Conf::CONF_OK)
+        {
+            throw KafkaError("Failed to set delivery reporting: " + error);
+        }
+    }
+
+    KafkaProducer::KafkaProducer(const std::string &brokers)
+        : producer_{nullptr, destroyProducer}
+    {
+        auto conf = createConfig();
+        configureCommonOptions(*conf, brokers);
+
+        std::string error;
+        RdKafka::Producer *rawProducer = RdKafka::Producer::create(conf.get(), error);
+        if (!rawProducer)
+        {
+            throw KafkaError("Failed to create Kafka producer: " + error);
+        }
+
+        producer_.reset(rawProducer);
+        std::clog << "[KafkaProducer] Created producer for " << brokers << "\n";
+    }
+
+    KafkaProducer::~KafkaProducer()
+    {
+        try
+        {
+            flush();
+        }
+        catch (const std::exception &ex)
+        {
+            std::clog << "[KafkaProducer] Exception during flush: " << ex.what() << '\n';
+        }
+    }
+
+    void KafkaProducer::produceMessages(const std::string &topic, const std::string &message)
+    {
+        if (!producer_)
+        {
+            throw KafkaError("Kafka producer is not initialised");
+        }
+
+        constexpr std::size_t maxRetries = 3;
+        for (std::size_t attempt = 0; attempt <= maxRetries; ++attempt)
+        {
+            auto error = producer_->produce(topic,
+                                            RdKafka::Topic::PARTITION_UA,
+                                            RdKafka::Producer::RK_MSG_COPY,
+                                            const_cast<char *>(message.data()),
+                                            message.size(),
+                                            nullptr,
+                                            0,
+                                            0,
+                                            nullptr,
+                                            nullptr);
+
+            if (error == RdKafka::ERR_NO_ERROR)
+            {
+                producer_->poll(0);
+                return;
+            }
+
+            if (error == RdKafka::ERR__QUEUE_FULL && attempt < maxRetries)
+            {
+                producer_->poll(1000);
+                continue;
+            }
+
+            throw KafkaError("Failed to produce to topic '" + topic + "': " + RdKafka::err2str(error));
+        }
+    }
+
+    void KafkaProducer::flush(std::chrono::milliseconds timeout)
+    {
+        if (!producer_)
+        {
+            return;
+        }
+
+        const auto flushResult = producer_->flush(static_cast<int>(timeout.count()));
+        if (flushResult != RdKafka::ERR_NO_ERROR)
+        {
+            std::clog << "[KafkaProducer] Flush finished with error: "
+                      << RdKafka::err2str(flushResult) << '\n';
+        }
+
+        const auto remaining = producer_->outq_len();
+        if (remaining > 0)
+        {
+            std::clog << "[KafkaProducer] " << remaining
+                      << " message(s) remaining in queue after flush." << '\n';
+        }
+    }
 }

--- a/app_kafka/src/kafka/KafkaProducer.h
+++ b/app_kafka/src/kafka/KafkaProducer.h
@@ -1,19 +1,45 @@
 #pragma once
-#include <iostream>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <stdexcept>
 #include <string>
+
 #include <librdkafka/rdkafkacpp.h>
+
+#include "DeliveryReportCb.h"
 
 namespace kafka
 {
+    class KafkaError : public std::runtime_error
+    {
+    public:
+        explicit KafkaError(const std::string &message) : std::runtime_error(message) {}
+    };
+
     class KafkaProducer
     {
     public:
-        RdKafka::Producer *producer;
-
-        KafkaProducer(std::string brokers);
-
-        void produceMessages(std::string topic, std::string message);
-
+        explicit KafkaProducer(const std::string &brokers);
         ~KafkaProducer();
+
+        KafkaProducer(const KafkaProducer &) = delete;
+        KafkaProducer &operator=(const KafkaProducer &) = delete;
+        KafkaProducer(KafkaProducer &&) noexcept = default;
+        KafkaProducer &operator=(KafkaProducer &&) noexcept = default;
+
+        void produceMessages(const std::string &topic, const std::string &message);
+        void flush(std::chrono::milliseconds timeout = std::chrono::seconds(10));
+
+    private:
+        using ProducerPtr = std::unique_ptr<RdKafka::Producer, std::function<void(RdKafka::Producer *)>>;
+        using ConfPtr = std::unique_ptr<RdKafka::Conf, std::function<void(RdKafka::Conf *)>>;
+
+        static ConfPtr createConfig();
+        void configureCommonOptions(RdKafka::Conf &conf, const std::string &brokers);
+
+        DeliveryReportCb deliveryReportCallback_;
+        ProducerPtr producer_{nullptr, [](RdKafka::Producer *) {}};
     };
 }

--- a/app_rabbitMQ/src/CMakeLists.txt
+++ b/app_rabbitMQ/src/CMakeLists.txt
@@ -1,29 +1,48 @@
 cmake_minimum_required(VERSION 3.25.2)
-project(app_rabbitmq)
 
-file(GLOB files
-     "*/*.cpp"
-)
+project(app_rabbitmq LANGUAGES CXX)
 
-find_package(rabbitmq-c REQUIRED)
-find_library(AMQP_CPP_LIBRARY NAMES amqpcpp PATHS /usr/local/lib REQUIRED)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+file(GLOB_RECURSE files
+     "${CMAKE_CURRENT_SOURCE_DIR}/rabbitMQ/*.cpp")
+
+find_package(rabbitmq-c QUIET)
+find_library(AMQP_CPP_LIBRARY NAMES amqpcpp PATHS /usr/local/lib /usr/lib /usr/lib64 /usr/local/lib64)
+find_path(AMQP_CPP_INCLUDE_DIR NAMES amqpcpp.h PATHS /usr/local/include /usr/include)
+
+if(NOT rabbitmq-c_FOUND OR NOT AMQP_CPP_LIBRARY OR NOT AMQP_CPP_INCLUDE_DIR)
+    message(WARNING "RabbitMQ dependencies were not found; building a header-only stub for app_rabbitmq")
+    add_library(${PROJECT_NAME} INTERFACE)
+    target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_compile_definitions(${PROJECT_NAME} INTERFACE APP_RABBITMQ_MISSING_DEPENDENCIES)
+    return()
+endif()
 
 add_library(${PROJECT_NAME} SHARED ${files})
-target_include_directories(${PROJECT_NAME} PUBLIC include)
-target_include_directories(${PROJECT_NAME} PUBLIC /usr/local/include)
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${AMQP_CPP_INCLUDE_DIR}
+)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE ${AMQP_CPP_LIBRARY}
-amqpcpp)
-
+target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+        rabbitmq::rabbitmq
+        ${AMQP_CPP_LIBRARY}
+)
 
 install(
-     DIRECTORY "${CMAKE_SOURCE_DIR}/rabbitMQ"
-     DESTINATION "include" 
-     FILES_MATCHING 
-     PATTERN "*.h" 
+     DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/rabbitMQ"
+     DESTINATION "include"
+     FILES_MATCHING
+     PATTERN "*.h"
 )
 
 install(TARGETS ${PROJECT_NAME}
+     EXPORT app_rabbitmqTargets
      RUNTIME DESTINATION bin
      ARCHIVE DESTINATION lib
      LIBRARY DESTINATION lib)

--- a/app_rabbitMQ/src/rabbitMQ/consumer.cpp
+++ b/app_rabbitMQ/src/rabbitMQ/consumer.cpp
@@ -1,39 +1,49 @@
-#include "iostream"
 #include "consumer.h"
 
-rabbitMQ::RabbitMQconsumer::RabbitMQconsumer() {}
+#include <stdexcept>
 
-rabbitMQ::RabbitMQconsumer::~RabbitMQconsumer() {}
-
-void rabbitMQ::RabbitMQconsumer::consumeMessages(std::string url, std::string queue)
+namespace rabbitMQ
 {
-    AMQP amqp(url);
-    rabbitMQqueue = amqp.createQueue(queue);
-    rabbitMQqueue->Declare();
+    RabbitMQconsumer::RabbitMQconsumer() = default;
 
-    while (consume)
+    RabbitMQconsumer::~RabbitMQconsumer() = default;
+
+    void RabbitMQconsumer::consumeMessages(const std::string &url, const std::string &queue)
     {
-    again:
-        rabbitMQqueue->Get(AMQP_NOACK);
-
-        AMQPMessage *rabbitMQmessage = rabbitMQqueue->getMessage();
-
-        if (rabbitMQmessage->getMessageCount() > -1)
+        AMQP amqp(url);
+        rabbitMQqueue.reset(amqp.createQueue(queue));
+        if (!rabbitMQqueue)
         {
-            uint32_t j = 0;
-            onMessage(rabbitMQmessage->getMessage(&j));
+            throw std::runtime_error("Failed to create queue: " + queue);
         }
-        else
-            goto again;
+
+        rabbitMQqueue->Declare();
+
+        while (consume.load(std::memory_order_acquire))
+        {
+            rabbitMQqueue->Get(AMQP_NOACK);
+
+            AMQPMessage *rabbitMQmessage = rabbitMQqueue->getMessage();
+            if (!rabbitMQmessage)
+            {
+                continue;
+            }
+
+            if (rabbitMQmessage->getMessageCount() > -1)
+            {
+                uint32_t j = 0;
+                onMessage(rabbitMQmessage->getMessage(&j));
+            }
+        }
     }
-}
 
-void rabbitMQ::RabbitMQconsumer::onMessage(std::string message)
-{
-    std::cout << "Message recieved: " << message << std::endl;
-}
+    void RabbitMQconsumer::onMessage(const std::string &message)
+    {
+        std::cout << "Message received: " << message << std::endl;
+    }
 
-void rabbitMQ::RabbitMQconsumer::stopConsume()
-{
-    consume = false;
+    void RabbitMQconsumer::stopConsume()
+    {
+        consume.store(false, std::memory_order_release);
+    }
 }

--- a/app_rabbitMQ/src/rabbitMQ/consumer.h
+++ b/app_rabbitMQ/src/rabbitMQ/consumer.h
@@ -1,19 +1,24 @@
 #pragma once
-#include "iostream"
+#include <atomic>
+#include <iostream>
+#include <memory>
+
 #include <AMQPcpp.h>
 
 namespace rabbitMQ
 {
-	class RabbitMQconsumer
-	{
-	public:
-		AMQPQueue *rabbitMQqueue;
-		bool consume = true;
+    class RabbitMQconsumer
+    {
+    public:
+        RabbitMQconsumer();
+        virtual ~RabbitMQconsumer();
 
-		RabbitMQconsumer();
-		~RabbitMQconsumer();
-		void consumeMessages(std::string url, std::string queue);
-		virtual void onMessage(std::string message);
-		void stopConsume();
-	};
+        void consumeMessages(const std::string &url, const std::string &queue);
+        virtual void onMessage(const std::string &message);
+        void stopConsume();
+
+    private:
+        std::unique_ptr<AMQPQueue> rabbitMQqueue;
+        std::atomic<bool> consume{true};
+    };
 }

--- a/app_rabbitMQ/src/rabbitMQ/producer.cpp
+++ b/app_rabbitMQ/src/rabbitMQ/producer.cpp
@@ -1,25 +1,42 @@
-#include "iostream"
 #include "producer.h"
 
-rabbitMQ::RabbitMQprocuder::RabbitMQprocuder()
+#include <iostream>
+#include <stdexcept>
+
+namespace rabbitMQ
 {
+    RabbitMQprocuder::RabbitMQprocuder() = default;
+
+    void RabbitMQprocuder::produceMessage(const std::string &url,
+                                          const std::string &exchange,
+                                          const std::string &queue,
+                                          const std::string &message,
+                                          const std::string &key)
+    {
+        AMQP amqp(url);
+
+        rabbitMQexchange = amqp.createExchange(exchange);
+        if (!rabbitMQexchange)
+        {
+            throw std::runtime_error("Failed to create exchange: " + exchange);
+        }
+
+        rabbitMQexchange->Declare(exchange, "fanout");
+
+        rabbitMQqueue = amqp.createQueue(queue);
+        if (!rabbitMQqueue)
+        {
+            throw std::runtime_error("Failed to create queue: " + queue);
+        }
+
+        rabbitMQqueue->Declare();
+        rabbitMQqueue->Bind(exchange, "");
+
+        rabbitMQexchange->setHeader("Delivery-mode", 2);
+        rabbitMQexchange->setHeader("Content-type", "text/text");
+        rabbitMQexchange->setHeader("Content-encoding", "UTF-8");
+        rabbitMQexchange->Publish(message, key);
+    }
+
+    RabbitMQprocuder::~RabbitMQprocuder() = default;
 }
-
-void rabbitMQ::RabbitMQprocuder::produceMessage(std::string url, std::string exchange, std::string queue, std::string message, std::string key)
-{
-    AMQP amqp(url);
-
-    rabbitMQexchange = amqp.createExchange(exchange);
-    rabbitMQexchange->Declare(exchange, "fanout");
-
-    rabbitMQqueue = amqp.createQueue(queue);
-    rabbitMQqueue->Declare();
-    rabbitMQqueue->Bind(exchange, "");
-
-    rabbitMQexchange->setHeader("Delivery-mode", 2);
-    rabbitMQexchange->setHeader("Content-type", "text/text");
-    rabbitMQexchange->setHeader("Content-encoding", "UTF-8");
-    rabbitMQexchange->Publish(message, key);
-}
-
-rabbitMQ::RabbitMQprocuder::~RabbitMQprocuder() {}

--- a/app_rabbitMQ/src/rabbitMQ/producer.h
+++ b/app_rabbitMQ/src/rabbitMQ/producer.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "iostream"
+#include <iostream>
 #include <AMQPcpp.h>
 
 namespace rabbitMQ
@@ -12,7 +12,11 @@ namespace rabbitMQ
 
     public:
         RabbitMQprocuder();
-        void produceMessage(std::string url, std::string exchange, std::string queue, std::string message, std::string key);
+        void produceMessage(const std::string &url,
+                            const std::string &exchange,
+                            const std::string &queue,
+                            const std::string &message,
+                            const std::string &key);
         ~RabbitMQprocuder();
     };
 }

--- a/app_utils/src/CMakeLists.txt
+++ b/app_utils/src/CMakeLists.txt
@@ -1,28 +1,54 @@
 cmake_minimum_required(VERSION 3.25.2)
+
+project(app_utils LANGUAGES CXX)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-project(app_utils)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-file(GLOB files
-     "*/*/*.cpp"
-)
+file(GLOB_RECURSE files
+     "${CMAKE_CURRENT_SOURCE_DIR}/utils/*.cpp")
 
-find_package(nlohmann_json REQUIRED)
+if(files STREQUAL "")
+    message(WARNING "app_utils: no source files were found")
+endif()
+
+find_package(nlohmann_json QUIET)
+
+if(NOT nlohmann_json_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        nlohmann_json
+        URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+        URL_HASH SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
+endif()
+
+if(NOT TARGET nlohmann_json::nlohmann_json)
+    message(FATAL_ERROR "nlohmann_json could not be located or fetched")
+endif()
 
 add_library(${PROJECT_NAME} SHARED ${files})
-target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE nlohmann_json::nlohmann_json)
-
+target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+        nlohmann_json::nlohmann_json
+)
 
 install(
-     DIRECTORY "${CMAKE_SOURCE_DIR}/utils" 
-     DESTINATION "include" 
-     FILES_MATCHING 
-     PATTERN "*.h" 
+     DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/utils"
+     DESTINATION "include"
+     FILES_MATCHING
+     PATTERN "*.h"
 )
 
 install(TARGETS ${PROJECT_NAME}
+     EXPORT app_utilsTargets
      RUNTIME DESTINATION bin
      ARCHIVE DESTINATION lib
      LIBRARY DESTINATION lib)

--- a/app_utils/src/utils/chrono/latency.cpp
+++ b/app_utils/src/utils/chrono/latency.cpp
@@ -1,14 +1,17 @@
 #include <iostream>
+#include <utility>
 
 #include "latency.h"
 #include "time.h"
 
 utils::Latency::Latency(std::string functionName)
+    : start(utils::Time::getEpocTimeInNanoseconds()),
+      functionName(std::move(functionName))
 {
-    this->functionName = functionName;
-    start = utils::Time::getEpocTimeInNanoseconds();
 }
+
 utils::Latency::~Latency()
 {
-    std::cout << functionName << " took : " << utils::Time::getEpocTimeInNanoseconds() - start << "nanoseconds" << std::endl;
+    const auto elapsed = utils::Time::getEpocTimeInNanoseconds() - start;
+    std::clog << functionName << " took: " << elapsed << " nanoseconds" << std::endl;
 }

--- a/app_utils/src/utils/chrono/latency.h
+++ b/app_utils/src/utils/chrono/latency.h
@@ -1,15 +1,13 @@
 #pragma once
-#include <iostream>
-#include <cstdint> 
+#include <cstdint>
+#include <string>
 
-namespace utils
-{
-    class Latency
-    {
+namespace utils {
+    class Latency {
     public:
         uint64_t start;
         std::string functionName;
-        Latency(std::string functionName);
+        explicit Latency(std::string functionName);
         ~Latency();
     };
 }

--- a/app_utils/src/utils/chrono/time.cpp
+++ b/app_utils/src/utils/chrono/time.cpp
@@ -1,6 +1,9 @@
-#include <iostream>
 #include <chrono>
 #include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <thread>
 
 #include "time.h"
 
@@ -31,76 +34,73 @@ uint64_t utils::Time::getEpocTimeInMinutes()
 
 void utils::Time::printNowTime()
 {
-    time_t now = time(0);
-    tm *ltm = localtime(&now);
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t timeValue = std::chrono::system_clock::to_time_t(now);
 
-    std::cout << "Year:" << 1900 + ltm->tm_year << std::endl;
-    std::cout << "Month: " << 1 + ltm->tm_mon << std::endl;
-    std::cout << "Day: " << ltm->tm_mday << std::endl;
-    std::cout << "Time: " << 5 + ltm->tm_hour << ":";
-    std::cout << 30 + ltm->tm_min << ":";
-    std::cout << ltm->tm_sec << std::endl;
+    std::tm tmSnapshot{};
+#if defined(_WIN32)
+    localtime_s(&tmSnapshot, &timeValue);
+#else
+    localtime_r(&timeValue, &tmSnapshot);
+#endif
+
+    std::cout << std::put_time(&tmSnapshot, "%Y-%m-%d %H:%M:%S") << std::endl;
 }
 
 void utils::Time::holdSeconds(int secs)
 {
-    long long int pre = utils::Time::getEpocTimeInMilliseconds();
-    bool hold = true;
-    while (hold)
+    if (secs <= 0)
     {
-        long long int now = utils::Time::getEpocTimeInMilliseconds();
-        if (now == (pre + (secs * 1000)))
-        {
-            hold = false;
-        }
+        return;
     }
+
+    std::this_thread::sleep_for(std::chrono::seconds(secs));
 }
 
 void utils::Time::holdMiliseconds(int miliseconds)
 {
-    long long int pre = utils::Time::getEpocTimeInMicroseconds();
-    bool hold = true;
-    while (hold)
+    if (miliseconds <= 0)
     {
-        long long int now = utils::Time::getEpocTimeInMicroseconds();
-        if (now == (pre + (miliseconds * 1000)))
-        {
-            hold = false;
-        }
+        return;
     }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(miliseconds));
 }
 
 std::string utils::Time::validTime(int i)
 {
-    std::string str;
-    if (i < 10)
+    if (i < 0)
     {
-        return str = "00" + std::to_string(i);
+        i = 0;
     }
-    else if (i < 100)
-    {
-        return str = "0" + std::to_string(i);
-    }
-    else
-    {
-        return str = std::to_string(i);
-    }
+
+    std::ostringstream stream;
+    stream << std::setfill('0') << std::setw(3) << i;
+    return stream.str();
 }
 
 std::string utils::Time::logTime()
 {
-    time_t now = time(0);
-    struct tm tstruct;
-    char log[80];
-    tstruct = *localtime(&now);
+    const auto now = std::chrono::system_clock::now();
+    const std::time_t timeValue = std::chrono::system_clock::to_time_t(now);
 
-    strftime(log, sizeof(log), "%Y-%m-%d %T", &tstruct);
+    std::tm tmSnapshot{};
+#if defined(_WIN32)
+    localtime_s(&tmSnapshot, &timeValue);
+#else
+    localtime_r(&timeValue, &tmSnapshot);
+#endif
 
-    int mili = getEpocTimeInMilliseconds() % 1000;
-    int micro = getEpocTimeInMicroseconds() % 1000;
-    int nano = getEpocTimeInNanoseconds() % 1000;
+    std::ostringstream logStream;
+    logStream << std::put_time(&tmSnapshot, "%Y-%m-%d %T");
 
-    std::string time = "[" + std::string(log) + ":" + validTime(mili) + ":" + validTime(micro) + ":" + validTime(nano) + "]";
+    const auto nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch());
+    const auto nanosCount = nanos.count();
+    const int milli = static_cast<int>((nanosCount / 1'000'000) % 1000);
+    const int micro = static_cast<int>((nanosCount / 1'000) % 1000);
+    const int nano = static_cast<int>(nanosCount % 1000);
 
-    return time;
+    std::ostringstream result;
+    result << '[' << logStream.str() << ':' << validTime(milli) << ':' << validTime(micro) << ':' << validTime(nano) << ']';
+    return result.str();
 }

--- a/app_utils/src/utils/chrono/time.h
+++ b/app_utils/src/utils/chrono/time.h
@@ -1,11 +1,9 @@
 #pragma once
-#include <iostream>
 #include <chrono>
+#include <iostream>
 
-namespace utils
-{
-    class Time
-    {
+namespace utils {
+    class Time {
     private:
         static std::string validTime(int i);
 

--- a/app_utils/src/utils/log/consoleLogger.cpp
+++ b/app_utils/src/utils/log/consoleLogger.cpp
@@ -1,10 +1,9 @@
 #include <iostream>
-#include <fstream>
 
 #include "../chrono/time.h"
 #include "consoleLogger.h"
 
-void utils::ConsoleLogger::info(std::string message)
+void utils::ConsoleLogger::info(const std::string &message)
 {
     std::cout << utils::Time::logTime() << " [INFO] " << message << "\n";
 }

--- a/app_utils/src/utils/log/consoleLogger.h
+++ b/app_utils/src/utils/log/consoleLogger.h
@@ -1,14 +1,11 @@
 #pragma once
-#include <iostream>
-#include <fstream>
+#include <string>
 
 #include "logger.h"
 
-namespace utils
-{
-    class ConsoleLogger : public Logger
-    {
+namespace utils {
+    class ConsoleLogger : public Logger {
     public:
-        void info(std::string message);
+        void info(const std::string &message) override;
     };
 }

--- a/app_utils/src/utils/log/fileLogger.cpp
+++ b/app_utils/src/utils/log/fileLogger.cpp
@@ -1,12 +1,12 @@
 #include "fileLogger.h"
-#include <iostream>
+
+#include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <fcntl.h>
 #include <unistd.h>
-#include <filesystem>
 #include <sys/file.h> // for flock
 
-#include "fileLogger.h"
 #include "../chrono/time.h"
 
 namespace fs = std::filesystem;
@@ -27,19 +27,20 @@ utils::FileLogger::~FileLogger() {}
 
 void utils::FileLogger::log(MessageCode level, const std::string &message)
 {
-    print(levelToString(level), message);
+    const std::string formatted = utils::Time::logTime() + " [" + levelToString(level) + "] " + message;
+    print(formatted);
 }
 
 void utils::FileLogger::logMeta(MessageCode level, const std::string &message,
                                 const char *file, int line, const char *func)
 {
-    std::string metadata = std::string(file) + ":" + std::to_string(line) +
-                           " in " + func;
-    std::string full_message = utils::Time::logTime() +" [" + levelToString(level) + "] " + metadata + " | " + message;
-    print(levelToString(level), full_message);
+    const std::string metadata = std::string(file) + ':' + std::to_string(line) +
+                                 " in " + func;
+    const std::string formatted = utils::Time::logTime() + " [" + levelToString(level) + "] " + metadata + " | " + message;
+    print(formatted);
 }
 
-void utils::FileLogger::print(const std::string &levelStr, const std::string &message)
+void utils::FileLogger::print(const std::string &message)
 {
     std::lock_guard<std::mutex> lock(logMutex);
 
@@ -58,7 +59,7 @@ void utils::FileLogger::print(const std::string &levelStr, const std::string &me
         return;
     }
 
-    std::string full_message = message + "\n";
+    const std::string full_message = message + '\n';
     if (write(fd, full_message.c_str(), full_message.size()) == -1)
     {
         perror("write");

--- a/app_utils/src/utils/log/fileLogger.h
+++ b/app_utils/src/utils/log/fileLogger.h
@@ -3,11 +3,9 @@
 #include <string>
 #include <mutex>
 
-namespace utils
-{
+namespace utils {
 
-    class FileLogger
-    {
+    class FileLogger {
     public:
         explicit FileLogger(const std::string &logFilePath = "log/log.txt");
         ~FileLogger();
@@ -25,7 +23,7 @@ namespace utils
                      const char *file, int line, const char *func);
 
     private:
-        void print(const std::string &levelStr, const std::string &message);
+        void print(const std::string &message);
         static std::string levelToString(MessageCode level);
         std::string logFilePath;
         static std::mutex logMutex;

--- a/app_utils/src/utils/log/logger.h
+++ b/app_utils/src/utils/log/logger.h
@@ -1,10 +1,10 @@
 #pragma once
-#include <iostream>
-#include <fstream>
+#include <string>
 
-namespace utils{
-    class Logger{
-        public:
-            virtual void info(std::string message) = 0;
+namespace utils {
+    class Logger {
+    public:
+        virtual ~Logger() = default;
+        virtual void info(const std::string &message) = 0;
     };
 }


### PR DESCRIPTION
## Summary
- promote the top-level build to C++17 with module toggles and optional Kafka/RabbitMQ stubs
- fetch nlohmann_json automatically for app_utils when it is not available system-wide
- refactor Kafka and RabbitMQ wrappers to use RAII, structured error handling, and informative logging

## Testing
- cmake --build .

------
https://chatgpt.com/codex/tasks/task_e_68d727ffa8b4833396822b74b3bf74de