### PR TITLE
Fix missing app_utils dependency across Conan packages

### DIFF
--- a/app_algorithms/src/CMakeLists.txt
+++ b/app_algorithms/src/CMakeLists.txt
@@ -5,13 +5,15 @@ file(GLOB files
      "*/*/*.cpp"
 )
 
+find_package(app_utils REQUIRED CONFIG)
+
 add_library(${PROJECT_NAME} SHARED ${files})
 
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        app_utils
+        app_utils::app_utils
 )
 
 install(

--- a/app_algorithms/src/conanfile.py
+++ b/app_algorithms/src/conanfile.py
@@ -10,3 +10,10 @@ class AlgorithmsRecipe(ConanFile):
         base.name = "app_algorithms"
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "algorithms/*"
+
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")

--- a/app_auth/src/CMakeLists.txt
+++ b/app_auth/src/CMakeLists.txt
@@ -14,6 +14,7 @@ if(files STREQUAL "")
 endif()
 
 find_package(OpenSSL REQUIRED)
+find_package(app_utils REQUIRED CONFIG)
 
 add_library(${PROJECT_NAME} SHARED ${files})
 target_include_directories(${PROJECT_NAME}
@@ -24,7 +25,7 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
         OpenSSL::Crypto
-        app_utils
+        app_utils::app_utils
 )
 
 install(

--- a/app_auth/src/conanfile.py
+++ b/app_auth/src/conanfile.py
@@ -9,3 +9,10 @@ class AuthRecipe(ConanFile):
         base.name = "app_auth"
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "auth/*"
+
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")

--- a/app_blokchain/src/CMakeLists.txt
+++ b/app_blokchain/src/CMakeLists.txt
@@ -8,12 +8,13 @@ file(GLOB files
 add_library(${PROJECT_NAME} SHARED ${files})
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 
+find_package(app_utils REQUIRED CONFIG)
 find_package(OpenSSL REQUIRED)
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
         OpenSSL::Crypto
-        app_utils
+        app_utils::app_utils
 )
 
 install(

--- a/app_blokchain/src/conanfile.py
+++ b/app_blokchain/src/conanfile.py
@@ -11,3 +11,10 @@ class kafkaRecipe(ConanFile):
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "blockchain/*"
 
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")
+

--- a/app_cache/src/CMakeLists.txt
+++ b/app_cache/src/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+find_package(app_utils REQUIRED CONFIG)
+
 file(GLOB_RECURSE files
      "${CMAKE_CURRENT_SOURCE_DIR}/cache/*.cpp")
 
@@ -21,7 +23,7 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        app_utils
+        app_utils::app_utils
 )
 
 install(

--- a/app_cache/src/conanfile.py
+++ b/app_cache/src/conanfile.py
@@ -9,3 +9,10 @@ class CacheRecipe(ConanFile):
         base.name = "app_cache"
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "cache/*"
+
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")

--- a/app_config/src/CMakeLists.txt
+++ b/app_config/src/CMakeLists.txt
@@ -13,6 +13,8 @@ if(files STREQUAL "")
     message(WARNING "app_config: no source files were found")
 endif()
 
+find_package(app_utils REQUIRED CONFIG)
+
 add_library(${PROJECT_NAME} SHARED ${files})
 target_include_directories(${PROJECT_NAME}
     PUBLIC
@@ -21,7 +23,7 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        app_utils
+        app_utils::app_utils
 )
 
 install(

--- a/app_config/src/conanfile.py
+++ b/app_config/src/conanfile.py
@@ -9,3 +9,10 @@ class ConfigRecipe(ConanFile):
         base.name = "app_config"
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "config/*"
+
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")

--- a/app_database/src/CMakeLists.txt
+++ b/app_database/src/CMakeLists.txt
@@ -7,6 +7,8 @@ file(GLOB files
      "*/*.cpp"
 )
 
+find_package(app_utils REQUIRED CONFIG)
+
 find_package(PkgConfig REQUIRED)
 
 # Find SQLite3 via pkg-config
@@ -49,7 +51,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
     ${SQLITE3_LIBRARIES}
     ${MYSQLCLIENT_LIB}
     ${POSTGRESQL_LIBRARIES}
-    app_utils
+    app_utils::app_utils
 )
 
 # Install headers and library

--- a/app_database/src/conanfile.py
+++ b/app_database/src/conanfile.py
@@ -11,3 +11,10 @@ class kafkaRecipe(ConanFile):
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "database/*"
 
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")
+

--- a/app_http/src/CMakeLists.txt
+++ b/app_http/src/CMakeLists.txt
@@ -8,6 +8,8 @@ file(GLOB files
      "*/*.cpp"
 )
 
+find_package(app_utils REQUIRED CONFIG)
+
 # First check the bundled copy that lives inside this repository so the
 # library can build even when the system doesn't provide `httplib.h`.
 set(_cppbase_httplib_hints
@@ -23,7 +25,7 @@ if(NOT HTTPLIB_INCLUDE_DIR)
     add_library(${PROJECT_NAME} INTERFACE)
     target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
     target_compile_definitions(${PROJECT_NAME} INTERFACE APP_HTTP_MISSING_DEPENDENCIES)
-    target_link_libraries(${PROJECT_NAME} INTERFACE app_utils)
+    target_link_libraries(${PROJECT_NAME} INTERFACE app_utils::app_utils)
     return()
 endif()
 
@@ -37,7 +39,7 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        app_utils
+        app_utils::app_utils
 )
 
 install(

--- a/app_http/src/conanfile.py
+++ b/app_http/src/conanfile.py
@@ -11,3 +11,10 @@ class kafkaRecipe(ConanFile):
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "http/*"
 
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")
+

--- a/app_kafka/src/CMakeLists.txt
+++ b/app_kafka/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 file(GLOB_RECURSE files
      "${CMAKE_CURRENT_SOURCE_DIR}/kafka/*.cpp")
 
+find_package(app_utils REQUIRED CONFIG)
 find_package(RdKafka QUIET)
 
 if(NOT RdKafka_FOUND)
@@ -16,9 +17,7 @@ if(NOT RdKafka_FOUND)
     add_library(${PROJECT_NAME} INTERFACE)
     target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
     target_compile_definitions(${PROJECT_NAME} INTERFACE APP_KAFKA_MISSING_DEPENDENCIES)
-    if(TARGET app_utils)
-        target_link_libraries(${PROJECT_NAME} INTERFACE app_utils)
-    endif()
+    target_link_libraries(${PROJECT_NAME} INTERFACE app_utils::app_utils)
     return()
 endif()
 
@@ -31,7 +30,7 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
         RdKafka::rdkafka++
-        app_utils
+        app_utils::app_utils
 )
 
 install(

--- a/app_kafka/src/conanfile.py
+++ b/app_kafka/src/conanfile.py
@@ -10,3 +10,10 @@ class kafkaRecipe(ConanFile):
         base.name = "app_kafka"
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "kafka/*"
+
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")

--- a/app_monitoring/src/CMakeLists.txt
+++ b/app_monitoring/src/CMakeLists.txt
@@ -13,6 +13,8 @@ if(files STREQUAL "")
     message(WARNING "app_monitoring: no source files were found")
 endif()
 
+find_package(app_utils REQUIRED CONFIG)
+
 add_library(${PROJECT_NAME} SHARED ${files})
 target_include_directories(${PROJECT_NAME}
     PUBLIC
@@ -21,7 +23,7 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
-        app_utils
+        app_utils::app_utils
 )
 
 install(

--- a/app_monitoring/src/conanfile.py
+++ b/app_monitoring/src/conanfile.py
@@ -9,3 +9,10 @@ class MonitoringRecipe(ConanFile):
         base.name = "app_monitoring"
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "monitoring/*"
+
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")

--- a/app_rabbitMQ/src/CMakeLists.txt
+++ b/app_rabbitMQ/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 file(GLOB_RECURSE files
      "${CMAKE_CURRENT_SOURCE_DIR}/rabbitMQ/*.cpp")
 
+find_package(app_utils REQUIRED CONFIG)
 find_package(rabbitmq-c QUIET)
 find_library(AMQP_CPP_LIBRARY NAMES amqpcpp PATHS /usr/local/lib /usr/lib /usr/lib64 /usr/local/lib64)
 find_path(AMQP_CPP_INCLUDE_DIR NAMES amqpcpp.h PATHS /usr/local/include /usr/include)
@@ -18,9 +19,7 @@ if(NOT rabbitmq-c_FOUND OR NOT AMQP_CPP_LIBRARY OR NOT AMQP_CPP_INCLUDE_DIR)
     add_library(${PROJECT_NAME} INTERFACE)
     target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
     target_compile_definitions(${PROJECT_NAME} INTERFACE APP_RABBITMQ_MISSING_DEPENDENCIES)
-    if(TARGET app_utils)
-        target_link_libraries(${PROJECT_NAME} INTERFACE app_utils)
-    endif()
+    target_link_libraries(${PROJECT_NAME} INTERFACE app_utils::app_utils)
     return()
 endif()
 
@@ -35,7 +34,7 @@ target_link_libraries(${PROJECT_NAME}
     PUBLIC
         rabbitmq::rabbitmq
         ${AMQP_CPP_LIBRARY}
-        app_utils
+        app_utils::app_utils
 )
 
 install(

--- a/app_rabbitMQ/src/conanfile.py
+++ b/app_rabbitMQ/src/conanfile.py
@@ -11,4 +11,11 @@ class rabbitMQRecipe(ConanFile):
         base.version = "1.0"
         base.exports_sources = "CMakeLists.txt", "rabbitMQ/*"
 
+    def requirements(self):
+        try:
+            super().requirements()
+        except AttributeError:
+            pass
+        self.requires("app_utils/1.0@pasan/testing")
+
  


### PR DESCRIPTION
## Summary
- use find_package/app_utils::app_utils in every consumer CMake target
- declare explicit Conan requirements on app_utils for dependent modules

## Testing
- not run (conan CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d74647eee48333995d77d7458658bb